### PR TITLE
macro get_source_path_from_gcov_filename should return absolute path,…

### DIFF
--- a/cmake/CoverallsGenerateGcov.cmake
+++ b/cmake/CoverallsGenerateGcov.cmake
@@ -169,8 +169,10 @@ macro(get_source_path_from_gcov_filename _SRC_FILENAME _GCOV_FILENAME)
 
 	# #path#to#project#root#subdir#the_file.c.gcov -> /path/to/project/root/subdir/the_file.c
 	string(REGEX REPLACE "\\.gcov$" "" SRC_FILENAME_TMP ${_GCOV_FILENAME_WEXT})
+	string(REGEX REPLACE "\\^" ".." SRC_FILENAME_TMP ${SRC_FILENAME_TMP})
 	string(REGEX REPLACE "\#" "/" SRC_FILENAME_TMP ${SRC_FILENAME_TMP})
-	set(${_SRC_FILENAME} "${SRC_FILENAME_TMP}")
+	get_filename_component(SRC_FILENAME_TMP_ABSOLUTE ${SRC_FILENAME_TMP} ABSOLUTE)
+	set(${_SRC_FILENAME} "${SRC_FILENAME_TMP_ABSOLUTE}")
 endmacro()
 
 ##############################################################################


### PR DESCRIPTION
macro get_source_path_from_gcov_filename should return absolute path, also ^ symbold should replace to up level(..)
if project have inner directory in which executed function coveralls_setup  appearst files with next filename ` ^#include#common#http#http.h.gcov` and get_source_path_from_gcov_filename can't stable it.