### PR TITLE
Fix: Merge coverage from multiple GCDA

### DIFF
--- a/cmake/CoverallsGenerateGcov.cmake
+++ b/cmake/CoverallsGenerateGcov.cmake
@@ -184,30 +184,29 @@ message("GCDA files:")
 # Get a list of all the object directories needed by gcov
 # (The directories the .gcda files and .o files are found in)
 # and run gcov on those.
-foreach(GCDA ${GCDA_FILES})
-	message("Process: ${GCDA}")
-	message("------------------------------------------------------------------------------")
-	get_filename_component(GCDA_DIR ${GCDA} PATH)
+message("Processing GCDA files")
+message("------------------------------------------------------------------------------")
+list(GET GCDA_FILES 0 FIRST_GCDA)
+get_filename_component(GCDA_DIR ${FIRST_GCDA} PATH)
 
-	#
-	# The -p below refers to "Preserve path components",
-	# This means that the generated gcov filename of a source file will
-	# keep the original files entire filepath, but / is replaced with #.
-	# Example:
-	#
-	# /path/to/project/root/build/CMakeFiles/the_file.dir/subdir/the_file.c.gcda
-	# ------------------------------------------------------------------------------
-	# File '/path/to/project/root/subdir/the_file.c'
-	# Lines executed:68.34% of 199
-	# /path/to/project/root/subdir/the_file.c:creating '#path#to#project#root#subdir#the_file.c.gcov'
-	#
-	# If -p is not specified then the file is named only "the_file.c.gcov"
-	#
-	execute_process(
-		COMMAND ${GCOV_EXECUTABLE} -p -o ${GCDA_DIR} ${GCDA}
-		WORKING_DIRECTORY ${COV_PATH}
-	)
-endforeach()
+#
+# The -p below refers to "Preserve path components",
+# This means that the generated gcov filename of a source file will
+# keep the original files entire filepath, but / is replaced with #.
+# Example:
+#
+# /path/to/project/root/build/CMakeFiles/the_file.dir/subdir/the_file.c.gcda
+# ------------------------------------------------------------------------------
+# File '/path/to/project/root/subdir/the_file.c'
+# Lines executed:68.34% of 199
+# /path/to/project/root/subdir/the_file.c:creating '#path#to#project#root#subdir#the_file.c.gcov'
+#
+# If -p is not specified then the file is named only "the_file.c.gcov"
+#
+execute_process(
+	COMMAND ${GCOV_EXECUTABLE} -p -o ${GCDA_DIR} ${GCDA_FILES}
+	WORKING_DIRECTORY ${COV_PATH}
+)
 
 # TODO: Make these be absolute path
 file(GLOB ALL_GCOV_FILES ${COV_PATH}/*.gcov)


### PR DESCRIPTION
Solves issue where coverage results overwrote each other.
Fixes #17 

Essentially, instead of calling gcov for each gcda file, just call it for all of them.