### PR TITLE
Add support for AppleClang

### DIFF
--- a/cmake/Coveralls.cmake
+++ b/cmake/Coveralls.cmake
@@ -112,7 +112,8 @@ endfunction()
 
 macro(coveralls_turn_on_coverage)
 	if(NOT (CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
-		AND (NOT "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang"))
+		AND (NOT "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+		AND (NOT "${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang"))
 		message(FATAL_ERROR "Coveralls: Compiler ${CMAKE_C_COMPILER_ID} is not GNU gcc! Aborting... You can set this on the command line using CC=/usr/bin/gcc CXX=/usr/bin/g++ cmake <options> ..")
 	endif()
 

--- a/cmake/Coveralls.cmake
+++ b/cmake/Coveralls.cmake
@@ -121,8 +121,8 @@ macro(coveralls_turn_on_coverage)
 		message(FATAL_ERROR "Coveralls: Code coverage results with an optimised (non-Debug) build may be misleading! Add -DCMAKE_BUILD_TYPE=Debug")
 	endif()
 
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 -fprofile-arcs -ftest-coverage")
-	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 -fprofile-arcs -ftest-coverage")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 -fprofile-arcs -ftest-coverage -coverage")
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 -fprofile-arcs -ftest-coverage -coverage")
 endmacro()
 
 


### PR DESCRIPTION
The compiler ID in recent CMake report AppleClang on Mac OS X, breaking the script.

This simple patch keep support for the old Clang (and it is probably the one needed for clang under linux) and add support for the clang under Mac OS X.